### PR TITLE
Fix compiling error introduced in #31789

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -4588,6 +4588,7 @@ template const monster *game::critter_at<monster>( const tripoint &, bool ) cons
 template const npc *game::critter_at<npc>( const tripoint &, bool ) const;
 template const player *game::critter_at<player>( const tripoint &, bool ) const;
 template const avatar *game::critter_at<avatar>( const tripoint &, bool ) const;
+template avatar *game::critter_at<avatar>( const tripoint &, bool );
 template const Character *game::critter_at<Character>( const tripoint &, bool ) const;
 template Character *game::critter_at<Character>( const tripoint &, bool );
 template const Creature *game::critter_at<Creature>( const tripoint &, bool ) const;


### PR DESCRIPTION

#### Summary
```SUMMARY: Bugfixes "Fix compiling error introduced in #31789"```

#### Purpose of change
Got compiling errors ```magic_teleporter_list.cpp:(.text+0x1ff5): undefined reference to `avatar* game::critter_at<avatar>(tripoint const&, bool)'``` after #31789 got merged.

#### Describe the solution
ifreund told me to add a line. Said line worked.

#### Describe alternatives you've considered
Waiting for someone else to get the same issue and fix it.
